### PR TITLE
QP-2766 - 2.0.4 - containers for build and fi test

### DIFF
--- a/build-in-docker.sh
+++ b/build-in-docker.sh
@@ -1,10 +1,14 @@
-CONTAINER=birdBuild
-GIT_BRANCH="${1:-2.0.4}"
+#
+# this runs the build-bird script in a container  (possibly having cached all the build dependencies)
+#
+CONTAINER=bird-build
+GIT_TAG="${1:-2.0.4-4.df}"
+ARCH=amd64
 # clear the source directory in the container
 docker exec $CONTAINER bash -c 'cd /home/support && rm -rf bird2 && mkdir -p bird2'
 # copy source from here to container
 docker cp ../bird2 $CONTAINER:/home/support
 # start the build
-docker exec $CONTAINER bash -c "cd /home/support/bird2 && bash -xe build-bird-2.0.4-4.df.sh ${GIT_BRANCH}"
+docker exec $CONTAINER bash -c "cd /home/support/bird2 && bash -xe build-bird-${GIT_TAG}.sh tag ${GIT_TAG}"
 # retrieve the debian from the container
-docker cp $CONTAINER:/home/support/bird2/bird2-2.0.4-4.df-amd64.deb .
+docker cp $CONTAINER:/home/support/bird2/bird2-${GIT_TAG}-${ARCH}.deb .

--- a/tools/df/docker/bird-build/Dockerfile
+++ b/tools/df/docker/bird-build/Dockerfile
@@ -1,0 +1,8 @@
+ARG BASE_IMAGE=276327358223.dkr.ecr.us-east-1.amazonaws.com/pipedream-dev
+ARG TAG=latest
+
+FROM ${BASE_IMAGE}:${TAG}
+
+RUN bash -c "apt-get update"
+# install build dependencies
+RUN bash -c "apt-get -y install build-essential autoconf flex bison git libncurses5-dev libreadline-dev debhelper" 

--- a/tools/df/docker/bird-build/build.sh
+++ b/tools/df/docker/bird-build/build.sh
@@ -1,0 +1,1 @@
+env DOCKER_BUILDKIT=1 docker build -t bird-build .

--- a/tools/df/docker/bird-build/run.sh
+++ b/tools/df/docker/bird-build/run.sh
@@ -1,0 +1,1 @@
+docker run --detach --name bird-build bird-build

--- a/tools/df/docker/bird-fi-test/Dockerfile
+++ b/tools/df/docker/bird-fi-test/Dockerfile
@@ -1,0 +1,17 @@
+# base image 
+ARG BASE_IMAGE=276327358223.dkr.ecr.us-east-1.amazonaws.com/pipedream-dev
+ARG TAG=latest
+ARG BIRD_TAG=2.0.4-4.df
+ARG ARCH=amd64
+
+FROM ${BASE_IMAGE}:${TAG}
+
+ENV BIRD_TAG=${BIRD_TAG}
+ENV ARCH=${ARCH}
+
+WORKDIR /home/support
+ADD media media
+
+# bird2-2.0.4-4.df-amd64.deb
+RUN bash -c "dpkg -i /home/support/media/bird2-2.0.4-4.df-amd64.deb"
+RUN bash -c "/usr/local/sbin/bird -c /usr/local/etc/bird.conf"

--- a/tools/df/docker/bird-fi-test/build.sh
+++ b/tools/df/docker/bird-fi-test/build.sh
@@ -1,0 +1,1 @@
+env DOCKER_BUILDKIT=1 docker build -t bird-fi-test .

--- a/tools/df/docker/bird-fi-test/run.sh
+++ b/tools/df/docker/bird-fi-test/run.sh
@@ -1,0 +1,10 @@
+IMAGE=bird-fi-test
+CONTAINER=bird-fi-test
+
+set -e
+docker run --detach --name ${CONTAINER} ${IMAGE}
+docker exec ${CONTAINER} bash -c 'echo $PATH'
+docker exec ${CONTAINER} bash -c "/usr/local/sbin/bird -c /usr/local/etc/bird.conf"
+docker exec ${CONTAINER} bash -c "/usr/local/sbin/birdc show proto"
+BGP_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${CONTAINER})
+docker exec ${CONTAINER} bash -c "env BGP_IP=$BGP_IP echo \"fi tests here and bgp on ${BGP_IP}\""


### PR DESCRIPTION
To isolate operating systems from injecting dependencies to libraries, I created 2 containers:

1. bird-build - a docker image and container that help building a docker debian package (sources in tools/df/docker/bird-build)
2. bird-fi-test - a docker image and container that has bird installed and runs it as root with the example configuration. This container is suitable for the fi tests from QP-2766 (sources in tools/df/docker/bird-fi-test)