### PR TITLE
DP-4605 IPv6 BGP showing nexthop as 255.255.255.255

### DIFF
--- a/proto/mrt/mrt.c
+++ b/proto/mrt/mrt.c
@@ -553,6 +553,7 @@ mrt_rib_table_entry(struct mrt_table_dump_state *s, rte *r)
          */
         if ( 16 == next_hop->u.ptr->length || 32 == next_hop->u.ptr->length) {
            ip6_addr *addr = (void *) s->bws->mp_next_hop->u.ptr->data;
+           // this is when the neighbor router is misbehaving - sending 2 nexthops is not really allowed by bgp
            if (32 == next_hop->u.ptr->length) {
              ip6_addr *addr2 = (void *) (s->bws->mp_next_hop->u.ptr->data + 16);
              // if ipv6 addr starts with 0xFE80, it's a link local address instead of nexthop

--- a/proto/mrt/mrt.c
+++ b/proto/mrt/mrt.c
@@ -551,7 +551,7 @@ mrt_rib_table_entry(struct mrt_table_dump_state *s, rte *r)
          * mp_next_hop is always encoded as ipv6 even when it's an ipv4
          * write mp_next_hop as an MP_REACH_NLRI field
          */
-        if ( 16 == next_hop->u.ptr->length ) {
+        if ( 16 == next_hop->u.ptr->length || 32 == next_hop->u.ptr->length) {
            ip6_addr *addr = (void *) s->bws->mp_next_hop->u.ptr->data;
            if (32 == next_hop->u.ptr->length) {
              ip6_addr *addr2 = (void *) (s->bws->mp_next_hop->u.ptr->data + 16);

--- a/proto/mrt/mrt.c
+++ b/proto/mrt/mrt.c
@@ -553,6 +553,14 @@ mrt_rib_table_entry(struct mrt_table_dump_state *s, rte *r)
          */
         if ( 16 == next_hop->u.ptr->length ) {
            ip6_addr *addr = (void *) s->bws->mp_next_hop->u.ptr->data;
+           if (32 == next_hop->u.ptr->length) {
+             ip6_addr *addr2 = (void *) (s->bws->mp_next_hop->u.ptr->data + 16);
+             // if ipv6 addr starts with 0xFE80, it's a link local address instead of nexthop
+             if ((addr->addr[0] & 0xFFFF0000) == 0xFE800000 && (addr2->addr[0] & 0xFFFF0000) != 0xFE800000) {
+                 addr == addr2;
+             }
+           }
+
            *end_attr_buf = next_hop->flags;
            *(end_attr_buf+1) = BA_MP_REACH_NLRI;
            /* don't have to write afi, safi - they are implied by rib table */


### PR DESCRIPTION
## Addresses

- [DP-4605](https://deepfield.atlassian.net/browse/DP-4605)

----

## The Problem
the nexthop is shown in birdc
```
bird> show route 2001:df2:e180::/48 table bgp_session_10_216_15_14_ipv6 all
Table bgp_session_10_216_15_14_ipv6:
2001:df2:e180::/48   unreachable [session_10_216_15_14 15:35:05.478 from 10.216.15.14] * (100/-) [AS140216i]
	Type: BGP univ
	BGP.origin: IGP
	BGP.as_path: 17676 6939 139901 140216
	BGP.next_hop: 2400:2000:4:0:1000::f5e fe80::aa0c:dff:fe5f:262a
	BGP.local_pref: 100
	BGP.community: (17676,320) (17676,433) (17676,439) (17676,3000) (17676,3004)
bird> 
```
but it's shown in mrt file as 255.255.255.255
```
support@softbank-worker04:/pipedream/cache/bgp/dumps$ bgpdump -m local_bgpdump.17676.10.216.15.14.ipv6.mrt | grep 2001:df2:e180::/48
2022-07-05 16:18:47 [info] logging to syslog
TABLE_DUMP_V2(2,1)|1657031910|B|10.216.15.14|17676|2001:df2:e180::/48|17676 6453 139901 140216|IGP|255.255.255.255|100|0|17676:320 17676:433 17676:439 17676:3000 17676:3004|NAG||
TABLE_DUMP_V2(2,1)|1657033710|B|10.216.15.14|17676|2001:df2:e180::/48|17676 6453 139901 140216|IGP|255.255.255.255|100|0|17676:320 17676:433 17676:439 17676:3000 17676:3004|NAG||

```

## Why This Solution?
reproduce it vlab:
the router send two nexthop addresses in one UPDATE bgp message. but gobgp and exabgp can't send this kind of message. So did a little modification on exabgp:
```
support@red-giant-worker01:~/exabgp$ git diff src/exabgp/bgp/message/update/attribute/mprnlri.py
diff --git a/src/exabgp/bgp/message/update/attribute/mprnlri.py b/src/exabgp/bgp/message/update/attribute/mprnlri.py
index b4ee87f4..e922e45f 100644
--- a/src/exabgp/bgp/message/update/attribute/mprnlri.py
+++ b/src/exabgp/bgp/message/update/attribute/mprnlri.py
@@ -83,7 +83,10 @@ class MPRNLRI(Attribute, Family):
             mpnlri.setdefault(nexthop, []).append(nlri.pack(negotiated))
         for nexthop, nlris in mpnlri.items():
-            payload = self.afi.pack() + self.safi.pack() + bytes([len(nexthop)]) + nexthop + bytes([0])
+            list_of_values = [0xfe, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xaa, 0x0c, 0x0d, 0xff, 0xfe, 0x5f, 0x26, 0x2a]
+
+            bvalues = bytes(list_of_values)
+            payload = self.afi.pack() + self.safi.pack() + bytes([len(nexthop) + len(bvalues)]) + nexthop + bvalues + bytes([0])
             header_length = len(payload)
             for nlri in nlris:
                 if self._len(payload + nlri) > maximum:
```

now, it can be reproduced in vlab.

After went through the code, found that if the length of `next_hop->u.ptr->length` is not 16, we will get a `255.255.255.255` in nexthop same as in the ticket
```
TABLE_DUMP_V2(2,1)|1661806114|B|10.0.130.28|65002|2001:df2:e180::/48|65002|INCOMPLETE|255.255.255.255|100|0||NAG||
```
https://github.com/deepfield/bird2/blob/1253ebc06fdccfe608d6ea2114cf58904e1232cf/proto/mrt/mrt.c#L554
but I went through the code, I found the variable should be set to 16. After I reproduced the issue in vlab, I do know my direction is right.
https://github.com/deepfield/bird2/blob/1253ebc06fdccfe608d6ea2114cf58904e1232cf/sysdep/linux/netlink.c#L1723


Above all, we should deal with the nexthop when  `next_hop->u.ptr->length` is 32.

----

### How to Test

run exabgp with the following config file:
```
neighbor 10.0.129.88 {                 # Remote neighbor to peer with
    router-id 172.16.2.1;              # Our local router-id
    local-address 10.0.130.28;          # Our local update-source
    local-as 65002;                    # Our local AS
    peer-as 65000;                     # Peer's AS
}
```

start bird2 with
```
sudo ./bird -d -f -c tools/df/conf/bird-mpls-vpn.conf
```

send announce message from exabgp
```
./exabgpcli announce route 2001:df2:e180::/48 next-hop 2400:2000:4:0:1000::f5e
```

get the nexthop from birdc
```
support@red-giant-master:~/bird2$ sudo birdc -s /usr/local/var/run/bird.ctl 
BIRD 2.0.4-7.df ready.
bird> show route 2001:df2:e180::/48 table master6 all
Table master6:
2001:df2:e180::/48   unreachable [gobgp 15:54:21.443 from 10.0.130.28] * (100/-) [AS65002i]
	Type: BGP univ
	BGP.origin: IGP
	BGP.as_path: 65002
	BGP.next_hop: 2400:2000:4:0:1000::f5e fe80::aa0c:dff:fe5f:262a
	BGP.local_pref: 100
```

run following command dump route table to mrt file
```
mrt dump table master6 to "a.mrt"
```

show the content in the mrt file:
```
bgpdump -v -m /home/support/bird2/a.mrt
```

### Screenshots

#### Before
```
TABLE_DUMP_V2(2,1)|1661900350|B|10.0.130.28|65002|2001:df2:e180::/48|65002|IGP|255.255.255.255|100|0||NAG||
TABLE_DUMP_V2(2,1)|1661900451|B|10.0.130.28|65002|2001:df2:e180::/48|65002|IGP|255.255.255.255|100|0||NAG||
TABLE_DUMP_V2(2,1)|1661900501|B|10.0.130.28|65002|2001:df2:e180::/48|65002|IGP|255.255.255.255|100|0||NAG||
```
#### After
```
TABLE_DUMP_V2(2,1)|1661900724|B|10.0.130.28|65002|2001:df2:e180::/48|65002|IGP|2400:2000:4:0:1000::f5e|100|0||NAG||
TABLE_DUMP_V2(2,1)|1661960519|B|10.0.130.28|65002|2001:df2:e180::/48|65002|IGP|2400:2000:4:0:1000::f5e|100|0||NAG||
```

