### PR TITLE
DP-4605 ipv6 bgp showing nexthop as 255 255 255 255

### DIFF
--- a/proto/mrt/mrt.c
+++ b/proto/mrt/mrt.c
@@ -558,7 +558,7 @@ mrt_rib_table_entry(struct mrt_table_dump_state *s, rte *r)
              ip6_addr *addr2 = (void *) (s->bws->mp_next_hop->u.ptr->data + 16);
              // if ipv6 addr starts with 0xFE80, it's a link local address instead of nexthop
              if ((addr->addr[0] & 0xFFFF0000) == 0xFE800000 && (addr2->addr[0] & 0xFFFF0000) != 0xFE800000) {
-                 addr == addr2;
+                 addr = addr2;
              }
            }
 


### PR DESCRIPTION
A follow-up PR https://github.com/deepfield/bird2/pull/14
fix a syntab bug