### PR TITLE
DP-5461 BIRD does-not write correct vpn6 mrt dumps 2

### DIFF
--- a/proto/mrt/mrt.c
+++ b/proto/mrt/mrt.c
@@ -495,6 +495,9 @@ mrt_rib_table_header(struct mrt_table_dump_state *s, net_addr *n)
   }
   else if ( n->type == NET_VPN6)
   {
+    // same to ipv4: Store as RIB_GENERIC - AFI - 2 SAFI 128
+    mrt_put_u16( b, BGP_AFI_IPV6);
+    mrt_put_u8(b, BGP_SAFI_MPLS_VPN);
     /* RFC 4659
        The NLRI field itself is encoded as specified in [MPLS-BGP].  In the
    context of this extension, the prefix belongs to the VPN-IPv6 Address


### PR DESCRIPTION
## Addresses

- [DP-5461](https://deepfield.atlassian.net/browse/DP-5461)

### Related PRs

- [PR for related](https://deepfield.atlassian.net/browse/DP-5461)
- [PR for related](https://deepfield.atlassian.net/browse/DP-5636)

----

## The Problem
1. compile bird2:
```
sudo apt-get update
sudo apt-get install libreadline-dev
autoreconf
bash -x ./tools/df/build/configure-debug.sh 
make
make install
```

2.  start bird
```
support@docker-host-unknown:~/nokiagithub/bird2$ sudo ./bird -d -f -c tools/df/conf/mpls-vpn.conf
bird: gobgp: Channel ipv4 connected to table master4
bird: gobgp: Channel ipv6 connected to table master6
bird: gobgp: Channel vpn4-mpls connected to table mastervpn4
bird: gobgp: Channel vpn6-mpls connected to table mastervpn6
bird: gobgp: Initializing
bird: mrt1: Initializing
bird: mrt2: Initializing
bird: gobgp2: Channel ipv4 connected to table master4
bird: gobgp2: Channel ipv6 connected to table master6
bird: gobgp2: Channel vpn4-mpls connected to table mastervpn4
bird: gobgp2: Channel vpn6-mpls connected to table mastervpn6
bird: gobgp2: Initializing
bird: gobgp: Starting
bird: gobgp: State changed to start
bird: mrt1: Starting
bird: mrt1: State changed to up
bird: mrt2: Starting
bird: mrt2: State changed to up
bird: gobgp2: Starting
bird: gobgp2: State changed to start
bird: Started
bird: gobgp2: Started
bird: gobgp2: Connect delayed by 5 seconds
bird: gobgp: Started
bird: gobgp: Connect delayed by 5 seconds

```

3. start gobgp and add some router simulators
```
gobgp global as 65002 router-id 10.0.0.2 listen-port 17000 listen-addresses 172.19.0.6
gobgp global as 65003 router-id 10.0.0.3 listen-port 17001 listen-addresses 172.19.0.6

gobgp nei add 172.19.0.6 as 65000 family ipv4-unicast,ipv6-unicast,l3vpn-ipv4-unicast,l3vpn-ipv6-unicast

gobgp vrf add globalvrf rd 2:2 rt both 2:2

gobgp global rib -a vpnv4 add 8.8.8.0/24 label 100 rd 100:100 origin incomplete nexthop 172.19.0.0 aspath 6919,16534 community no-export,no-advertise
gobgp global rib -a vpnv6 add 2001:df2:e180::/48 label 100 rd 100:100 origin incomplete nexthop 172.22.0.0 aspath 6919,16534 community no-export,no-advertise
```

4. bird connect to gobgp
```
bird: gobgp2: Connecting to 172.20.0.6 from local address 172.20.0.6
bird: gobgp2: Connected
bird: gobgp2: Sending OPEN(ver=4,as=65000,hold=240,id=0a000001)
bird: gobgp2: Got OPEN(as=65003,hold=90,id=10.0.0.3)
bird: gobgp2: Sending KEEPALIVE
bird: gobgp2: Got KEEPALIVE
bird: gobgp2: BGP session established
bird: gobgp2: Missing next hop address
bird: gobgp2: State changed to up
bird: gobgp2: Sending END-OF-RIB
{"Key":"172.20.0.6","State":"BGP_FSM_OPENCONFIRM","Topic":"Peer","level":"info","msg":"Peer Up","time":"2023-10-30T16:45:32Z"}
bird: gobgp2: Sending END-OF-RIB
bird: gobgp2: Sending END-OF-RIB
bird: gobgp2: Sending END-OF-RIB
bird: gobgp2: Got UPDATE
bird: gobgp2 > added [best] 100:100 8.8.8.0/24 unreachable
bird: gobgp2 < rejected by protocol 100:100 8.8.8.0/24 unreachable
bird: gobgp2: Got UPDATE
bird: gobgp2 > added [best] 100:100 2001:df2:e180::/48 unreachable
bird: gobgp2 < rejected by protocol 100:100 2001:df2:e180::/48 unreachable
bird: gobgp: Connecting to 172.20.0.6 from local address 172.20.0.6
bird: gobgp: Connected
bird: gobgp: Sending OPEN(ver=4,as=65000,hold=240,id=0a000001)
```
5. after 1 minute, get the mrt files and check them
```
support@docker-host-unknown:~/nokiagithub/bird2$ bgpdump -v ./demomastervpn4.mrt
TIME: 10/30/23 16:20:15
TYPE: TABLE_DUMP_V2/RIB_GENERIC
PREFIX: 100:100 8.8.8.0/112
SEQUENCE: 0
FROM: 172.20.0.6 AS65003
ORIGINATED: 10/30/23 16:19:18
ORIGIN: INCOMPLETE
ASPATH: 65003 6919 16534
LOCAL_PREF: 100
MP_REACH_NLRI(IPv6 Unicast)
NEXT_HOP: ::ffff:172.20.0.0
COMMUNITY: no-export no-advertise

TIME: 10/30/23 16:21:16
TYPE: TABLE_DUMP_V2/RIB_GENERIC
PREFIX: 100:100 8.8.8.0/112
SEQUENCE: 0
FROM: 172.20.0.6 AS65003
ORIGINATED: 10/30/23 16:19:18
ORIGIN: INCOMPLETE
ASPATH: 65003 6919 16534
LOCAL_PREF: 100
MP_REACH_NLRI(IPv6 Unicast)
NEXT_HOP: ::ffff:172.20.0.0
COMMUNITY: no-export no-advertise

support@docker-host-unknown:~/nokiagithub/bird2$ bgpdump -v ./demomastervpn6.mrt
support@docker-host-unknown:~/nokiagithub/bird2$

```
6. the problem is ipv6 mrt file can't dump any information.


## Why This Solution?
1. compare the format of ipv4 mrt file and ipv5

hexdump v4:

```bash
support@docker-host-unknown:~/nokiagithub/bird2$ python tools/df/mrt_analysis.py --bgp --hexdump mastervpn4.mrt

--------------------------------------------------------------------------------
Header #238 - Type - 13 - SubType 1 - 0045 bytes
00004cb7  65 3a d9 1b 00 0d 00 01  00 00 00 45                  
Payload - 69 bytes
00004cc3  0a 00 00 01 00 0a 6d 61  73 74 65 72 76 70 6e 36  
00004cd3  00 03 03 00 00 00 00 00  00 00 00 00 00 00 00 00  
00004ce3  00 00 00 00 00 00 00 00  00 00 00 02 00 00 00 00  
00004cf3  ac 13 00 06 00 00 fd ea  02 0a 00 00 03 ac 13 00  
00004d03  06 00 00 fd eb                                               
--------------------------------------------------------------------------------
Header #239 - Type - 13 - SubType 6 - 005b bytes
00004d08  65 3a d9 1b 00 0d 00 06  00 00 00 5b                  
Payload - 91 bytes
00004d14  00 00 00 00 88 00 00 01  64 00 00 00 64 00 00 00  
00004d24  20 01 0d f2 e1 80 00 01  00 02 65 3a d8 2d 00 3b  
00004d34  40 01 01 02 40 02 0e 02  03 00 00 fd eb 00 00 1b  
00004d44  07 00 00 40 96 00 05 04  00 00 00 64 c0 08 08 ff  
00004d54  ff ff 01 ff ff ff 02 00  0e 11 10 00 00 00 00 00  
00004d64  00 00 00 00 00 ff ff ac  16 00 00
```

hexdump v6:

```bash
--------------------------------------------------------------------------------
Header #107 - Type - 13 - SubType 1 - 0038 bytes
00001c6c  65 3b c2 54 00 0d 00 01  00 00 00 38                  
Payload - 56 bytes
00001c78  0a 00 00 01 00 0a 6d 61  73 74 65 72 76 70 6e 36  
00001c88  00 02 03 00 00 00 00 00  00 00 00 00 00 00 00 00  
00001c98  00 00 00 00 00 00 00 00  00 00 00 02 00 00 00 00  
00001ca8  ac 13 00 06 00 00 fd ea                                   
--------------------------------------------------------------------------------
Header #108 - Type - 13 - SubType 1 - 0038 bytes
00001cb0  65 3b c2 8f 00 0d 00 01  00 00 00 38                  
Payload - 56 bytes
00001cbc  0a 00 00 01 00 0a 6d 61  73 74 65 72 76 70 6e 36  
00001ccc  00 02 03 00 00 00 00 00  00 00 00 00 00 00 00 00  
00001cdc  00 00 00 00 00 00 00 00  00 00 00 02 00 00 00 00  
00001cec  ac 13 00 06 00 00 fd ea
```

2. the bytes are missing

## mrt file format

message header:
```c
 
   // rib generic - we support AFI 1/2 and SAFI 128
	/*
	        0                   1                   2                   3
		0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
		+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
		|                         Sequence Number                       |
		+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
		|    Address Family Identifier  |Subsequent AFI |
		+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
		|     Network Layer Reachability Information (variable)         |
		+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
		|         Entry Count           |  RIB Entries (variable)
		+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
	 */
```

message body:
```python
"""
            0                   1                   2                   3
            0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
           |                           Timestamp                           |
           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
           |             Type              |            Subtype            |
           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
           |                             Length                            |
           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
           |                      Message... (variable)
           +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
    """
```

`|             Type              |            Subtype            |` are missing
4. check the code， found two lines code are missing


## Test
- Before:
see the section of Problem

- After:
```
support@docker-host-unknown:~/nokiagithub/bird2$ bgpdump -v ./demomastervpn6.mrt
TIME: 10/30/23 16:46:31
TYPE: TABLE_DUMP_V2/RIB_GENERIC
PREFIX: 100:100 2001:df2:e180::/136
SEQUENCE: 0
FROM: 172.20.0.6 AS65003
ORIGINATED: 10/30/23 16:45:32
ORIGIN: INCOMPLETE
ASPATH: 65003 6919 16534
LOCAL_PREF: 100
MP_REACH_NLRI(IPv6 Unicast)
NEXT_HOP: ::ffff:172.22.0.0
COMMUNITY: no-export no-advertise

TIME: 10/30/23 16:47:31
TYPE: TABLE_DUMP_V2/RIB_GENERIC
PREFIX: 100:100 2001:df2:e180::/136
SEQUENCE: 0
FROM: 172.20.0.6 AS65003
ORIGINATED: 10/30/23 16:45:32
ORIGIN: INCOMPLETE
ASPATH: 65003 6919 16534
LOCAL_PREF: 100
MP_REACH_NLRI(IPv6 Unicast)
NEXT_HOP: ::ffff:172.22.0.0
COMMUNITY: no-export no-advertise

TIME: 10/30/23 16:48:31
TYPE: TABLE_DUMP_V2/RIB_GENERIC
PREFIX: 100:100 2001:df2:e180::/136
SEQUENCE: 0
FROM: 172.20.0.6 AS65003
ORIGINATED: 10/30/23 16:45:32
ORIGIN: INCOMPLETE
ASPATH: 65003 6919 16534
LOCAL_PREF: 100
MP_REACH_NLRI(IPv6 Unicast)
NEXT_HOP: ::ffff:172.22.0.0
COMMUNITY: no-export no-advertise

``` 




[DP-5461]: https://deepfield.atlassian.net/browse/DP-5461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ