### PR TITLE
DP-6039  master BIRD-writes-nexthop-255-255-255-255

### DIFF
--- a/proto/mrt/mrt.c
+++ b/proto/mrt/mrt.c
@@ -567,13 +567,16 @@ mrt_table_dump_free(struct mrt_table_dump_state *s)
 static int
 mrt_table_dump_step(struct mrt_table_dump_state *s)
 {
-  struct bgp_write_state bws = { .as4_session = 1 };
-
-  s->max = 2048;
-  s->bws = &bws;
-
-  if (s->table_open)
+  if (s->table_open) {
+    // continue to dump next 2048 entries
+    s->max = 2048;
     goto step;
+  }
+  else {
+    struct bgp_write_state bws = { .as4_session = 1 };
+    s->max = 2048;
+    s->bws = &bws;
+  }
 
   while (mrt_next_table(s))
   {

--- a/proto/mrt/mrt.c
+++ b/proto/mrt/mrt.c
@@ -567,16 +567,14 @@ mrt_table_dump_free(struct mrt_table_dump_state *s)
 static int
 mrt_table_dump_step(struct mrt_table_dump_state *s)
 {
-  if (s->table_open) {
-    // continue to dump next 2048 entries
-    s->max = 2048;
+  struct bgp_write_state bws = { .as4_session = 1 };
+
+  s->max = 2048;
+  s->bws = &bws;
+
+  if (s->table_open)
+    s->bws->mp_reach = !s->ipv4;
     goto step;
-  }
-  else {
-    struct bgp_write_state bws = { .as4_session = 1 };
-    s->max = 2048;
-    s->bws = &bws;
-  }
 
   while (mrt_next_table(s))
   {

--- a/proto/mrt/mrt.c
+++ b/proto/mrt/mrt.c
@@ -572,9 +572,10 @@ mrt_table_dump_step(struct mrt_table_dump_state *s)
   s->max = 2048;
   s->bws = &bws;
 
-  if (s->table_open)
+  if (s->table_open) {
     s->bws->mp_reach = !s->ipv4;
     goto step;
+  }
 
   while (mrt_next_table(s))
   {


### PR DESCRIPTION
## Addresses

- [DP-6093](https://deepfield.atlassian.net/browse/DP-6011)

----

## The Problem
```
support@k2-brazil-worker02:~$ bgpdump -m /pipedream/cache/bgp/dumps/local_bgpdump.53181.10.250.100.200.ipv6.mrt |grep '|255.255.255.255|' |wc -l
2024-05-17 17:34:06 [info] logging to syslog
395637
support@k2-brazil-worker02:~$
support@k2-brazil-worker02:~$ bgpdump -m /pipedream/cache/bgp/dumps/local_bgpdump.53181.10.250.100.200.ipv6.mrt |grep -v '|255.255.255.255|' |wc -l
2024-05-17 18:36:19 [info] logging to syslog
2048
support@k2-brazil-worker02:~$
```
next hop is 255.255.255.255, that is not right.

## Why This Solution?

### Investigate:
- why bgpdump show 255?
if there is no NLRI, it will print 255.255.255.255 as next hop

- There is no NLRI in mrt, really? How to verify it?
read mrt file byte by byte? No
use a third party tool (https://github.com/t2mune/mrtparse/tree/master/examples) to analyse the mrt file, got same result. 
**so the problem is not in bgpdump** 

- why NLRI attributes not in mrt
```
    // add the nexthop if mp_reach was 
    if ( s->bws->mp_reach && s->bws->mp_next_hop) {
         ... ...
         if ( 16 == next_hop->u.ptr->length || 32 == next_hop->u.ptr->length) {
              ... ...
```

### Carefully read tcpdump messages, I can't find the reason.
found some weird messages but the problem is not caused by them:
- there is different ways to write the nexthop - technically ::ffff::a.b.c.d is a reserved ipv6 address range for ipv4 mapped addresses
- well technically the extended length bit just means use 2 octets to encode the length instead of one (it implies the length is >255 - but does not have to be)
- we can ignore the mpls label stack because we don't do mpls - we do ip
https://nokiadeepfield.slack.com/archives/D03VAQ6KGQY/p1715633023535849 
- but **found another problem** about the labelled msg (https://deepfield.atlassian.net/browse/CPL-16233) 

### Read bird code, I can't find the reason in short term
- bird2 code is a bit messy (alignment) and really complicated (structure, protocals, configuration)

### How to reproduce 
It's very difficult to reproduce the problem in development
1. check the messages in pcap from k2. --- no problem found
2. replayed a few messages of k2's pcap, **no error**
3. **unable to replay all messages** to bird2, bird2 closes connection after a while
4. generated over 2k ipv6 UPDATE messages by modifying exabgp code, reproduced the issue
 
### Debug bird2
1. make bird2 configuration simple (only has ipv5 table). bird2 use bison to construct its configuration
2. bird2 dump 2k entries at most every event. (bird2 use event instead of thread to do multi task)
3. Finally, bingo! the culprit is `goto` command. it is terrible

### The original bird2 code () has the same bug. might need to report it too.


----

### How to Test
1. change exbgp code:
```
def new_update(self, include_withdraw):
        global send_index
        updates = self.neighbor.rib.outgoing.updates(self.neighbor.group_updates)
        number = 0
        i = send_index
        flagb = False
        for update in updates:
            for message in update.messages(self.negotiated, include_withdraw):
                number += 1
                # for boolean in self.send(message):
                #     # boolean is a transient network error we already announced
                #     yield _NOP
                
                from scapy.all import TCP,rdpcap,Raw
                pcap_file = "/home/support/pipedream/bgp_totalplay444.pcap"
                packets = rdpcap(pcap_file, 2)
                import ipaddress
                import random

                def generate_random_valid_ipv6_byte_array():
                    while True:
                        try:
                            ipv6_address = ipaddress.IPv6Address(random.getrandbits(128))
                            byte_array = ipv6_address.packed[:5]  # Get the first 5 bytes of the IPv6 address
                            return bytes(byte_array)
                        except ValueError:
                            pass

                num_addresses = 5000
                valid_ipv6_byte_arrays = [generate_random_valid_ipv6_byte_array() for _ in range(num_addresses)]

                # for k in [(0,500), (800, 1100), (2000, 2100), (3000, 3300), (4000, 4090), (4500, 4640), (5500, 5690)]:
                for i in range(2200):
                    packet = packets[0]
                    
                    if TCP in packet and Raw in packet:
                        bytes_array2 = bytearray(bytes(packet[TCP].payload))
                        bytes_array = bytearray(b'1234567890123456')
                        bytes_array = copy.deepcopy(bytes_array2)
                        # bytes_array = bytes.fromhex(string_hex)
                        bytes_array[-1] = valid_ipv6_byte_arrays[i][-1]
                        bytes_array[-2] = valid_ipv6_byte_arrays[i][-2]
                        bytes_array[-3] = valid_ipv6_byte_arrays[i][-3]
                        bytes_array[-4] = valid_ipv6_byte_arrays[i][-4]
                        bytes_array[-5] = valid_ipv6_byte_arrays[i][-5]
                        bytes_array = bytes(bytes_array)
                        for boolean in self.send(bytes_array):
                            # boolean is a transient network error we already announced
                            yield _NOP
                        print(f"-------{i}-----------")
                        # if i - send_index > 5000:
                        #     flagb = True
                        #     break
                        sleep(0.02)

                if flagb:
                    break
            if flagb:
                break

        send_index = i
        print(f"-------{send_index}-----------")


        if number:
            self.logger.debug('>> %d UPDATE(s)' % number, self.connection.session())
        yield _UPDATE
```
2. add the exbgp config

```
$ cat exabgp.conf2
neighbor 172.28.0.6 {                 # Remote neighbor to peer with
    router-id 172.16.2.1;              # Our local router-id
    local-address 172.28.0.6;          # Our local update-source
    local-as 65002;                    # Our local AS
    peer-as 65000;                     # Peer's AS
}
```
my ip:
```
(deepfield-env) support@docker-host-unknown:/pipedream/local/venv/deepfield-env/lib/python3.11/site-packages/exabgp$ ifconfig
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 172.28.0.6  netmask 255.255.0.0  broadcast 172.28.255.255
```

5. start exabgp and 
```
exabgp ./exabgp.conf2

// send the first route entry to start 2k messages
(deepfield-env) support@docker-host-unknown:/pipedream/local/venv/deepfield-env/lib/python3.11/site-packages/exabgp$ exabgpcli announce route 2001:df2:e187::/48 next-hop 2400:2000:4:0:1000::f5e
```
 6. exbgp output logs:
```
-------2195-----------
-------2196-----------
-------2197-----------
-------2198-----------
-------2199-----------
-------2199-----------
```
7. bird2 output:
```
bird: ...
bird: gobgp: Discarding LOCAL_PREF attribute received from EBGP neighbor
bird: gobgp: Discarding ORIGINATOR_ID attribute received from EBGP neighbor
bird: gobgp: Discarding CLUSTER_LIST attribute received from EBGP neighbor
bird: gobgp > added [best] a62f:57c::/36 unreachable
bird: gobgp < rejected by protocol a62f:57c::/36 unreachable
bird: gobgp: Discarding LOCAL_PREF attribute received from EBGP neighbor
bird: gobgp: Discarding ORIGINATOR_ID attribute received from EBGP neighbor
bird: gobgp: Discarding CLUSTER_LIST attribute received from EBGP neighbor
bird: gobgp > added [best] dbe3:e6b8:8000::/36 unreachable
bird: gobgp < rejected by protocol dbe3:e6b8:8000::/36 unreachable
bird: gobgp: Discarding LOCAL_PREF attribute received from EBGP neighbor
bird: gobgp: Discarding ORIGINATOR_ID attribute received from EBGP neighbor
bird: gobgp: Discarding CLUSTER_LIST attribute received from EBGP neighbor
bird: Ignoring bogus route ff0e:85cc:c000::/36 received via gobgp
bird: gobgp > invalid ff0e:85cc:c000::/36 unreachable
bird: gobgp: Discarding LOCAL_PREF attribute received from EBGP neighbor
bird: gobgp: Discarding ORIGINATOR_ID attribute received from EBGP neighbor
bird: gobgp: Discarding CLUSTER_LIST attribute received from EBGP neighbor
bird: gobgp > added [best] 68b2:623a:9000::/36 unreachable
bird: gobgp < rejected by protocol 68b2:623a:9000::/36 unreachable
bird: gobgp: Discarding LOCAL_PREF attribute received from EBGP neighbor
bird: gobgp: Discarding ORIGINATOR_ID attribute received from EBGP neighbor
bird: gobgp: Discarding CLUSTER_LIST attribute received from EBGP neighbor
bird: gobgp > added [best] c8:f9a7:b000::/36 unreachable
bird: gobgp < rejected by protocol c8:f9a7:b000::/36 unreachable
bird: gobgp: Discarding LOCAL_PREF attribute received from EBGP neighbor
bird: gobgp: Discarding ORIGINATOR_ID attribute received from EBGP neighbor
bird: gobgp: Discarding CLUSTER_LIST attribute received from EBGP neighbor
bird: gobgp > added [best] 520e:6aac:f000::/36 unreachable
bird: gobgp < rejected by protocol 520e:6aac:f000::/36 unreachable
bird: gobgp: Got KEEPALIVE
bird: gobgp: Sending KEEPALIVE
bird: mrt1: RIB table dump started
bird: mrt4: RIB table dump started
bird: mrt2: RIB table dump started
bird: mrt5: RIB table dump started
bird: mrt3: RIB table dump started
bird: mrt4: RIB table dump done
bird: mrt2: RIB table dump done
bird: mrt5: RIB table dump done
bird: mrt3: RIB table dump done
bird: mrt1: RIB table dump done
```
8. check the 255.255.255.255

### Screenshots

#### Before
```
support@docker-host-unknown:~/nokiagithub/bird2$ ../../pipedream/third-party/ripencc-bgpdump/bgpdump -m -v ipv6.mrt | grep 255.255.255.255 | wc -l
18544
support@docker-host-unknown:~/nokiagithub/bird2$ ../../pipedream/third-party/ripencc-bgpdump/bgpdump -m -v ipv6.mrt | wc -l
34944
```

#### After
```
support@docker-host-unknown:~/nokiagithub/bird2$ ../../pipedream/third-party/ripencc-bgpdump/bgpdump -m -v ipv6.mrt | wc -l
165984
support@docker-host-unknown:~/nokiagithub/bird2$ ../../pipedream/third-party/ripencc-bgpdump/bgpdump -m -v ipv6.mrt | grep 255.255.255.255 | wc -l
0
```



[DP-6011]: https://deepfield.atlassian.net/browse/DP-6011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DP-6093]: https://deepfield.atlassian.net/browse/DP-6093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ